### PR TITLE
画像をdrag&dropしたときに新規ウィンドウが開き、画像が表示されるのを防ぐ

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1164,6 +1164,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 
 					// This is triggered when an external file is dropped on the editor
 					editor.on('drop', (event: any) => {
+						event.preventDefault();
 						props_onDrop.current(event);
 					});
 


### PR DESCRIPTION
画像をdrag&dropしたときに新規ウィンドウが開き、画像が表示されるのを防ぐ